### PR TITLE
v13: Create an error order when the payment is declined by PayPal

### DIFF
--- a/src/Umbraco.Commerce.PaymentProviders.PayPal/Api/Exceptions/PaymentDeclinedException.cs
+++ b/src/Umbraco.Commerce.PaymentProviders.PayPal/Api/Exceptions/PaymentDeclinedException.cs
@@ -1,0 +1,19 @@
+using System;
+
+namespace Umbraco.Commerce.PaymentProviders.PayPal.Api.Exceptions
+{
+    public class PaymentDeclinedException : Exception
+    {
+        public PaymentDeclinedException() : base("Payment is declined by Paypal")
+        {
+        }
+
+        public PaymentDeclinedException(string message) : base(message)
+        {
+        }
+
+        public PaymentDeclinedException(string message, Exception innerException) : base(message, innerException)
+        {
+        }
+    }
+}

--- a/src/Umbraco.Commerce.PaymentProviders.PayPal/Api/PayPalClient.cs
+++ b/src/Umbraco.Commerce.PaymentProviders.PayPal/Api/PayPalClient.cs
@@ -8,6 +8,7 @@ using System.Text.Json.Serialization;
 using System.Threading;
 using System.Threading.Tasks;
 using Flurl.Http;
+using Umbraco.Commerce.PaymentProviders.PayPal.Api.Exceptions;
 using Umbraco.Commerce.PaymentProviders.PayPal.Api.Models;
 
 namespace Umbraco.Commerce.PaymentProviders.PayPal.Api
@@ -49,22 +50,54 @@ namespace Umbraco.Commerce.PaymentProviders.PayPal.Api
 
         public async Task<PayPalOrder> AuthorizeOrderAsync(string orderId, CancellationToken cancellationToken = default)
         {
-            return await RequestAsync($"/v2/checkout/orders/{orderId}/authorize", async (req, ct) => await req
-                .WithHeader("Prefer", "return=representation")
-                .PostJsonAsync(null, cancellationToken: ct)
-                .ReceiveJson<PayPalOrder>().ConfigureAwait(false),
+            try
+            {
+                PayPalOrder paypalOrder = await RequestAsync(
+                $"/v2/checkout/orders/{orderId}/authorize",
+                async (req, ct) => await req
+                    .WithHeader("Prefer", "return=representation")
+                    .PostJsonAsync(null, cancellationToken: ct)
+                    .ReceiveJson<PayPalOrder>().ConfigureAwait(false),
                 cancellationToken)
                 .ConfigureAwait(false);
+
+                return paypalOrder;
+            }
+            catch (FlurlHttpException ex)
+            {
+                if (ex.Call.Response.StatusCode == 422)
+                {
+                    throw new PaymentDeclinedException();
+                }
+
+                throw;
+            }
         }
 
         public async Task<PayPalOrder> CaptureOrderAsync(string orderId, CancellationToken cancellationToken = default)
         {
-            return await RequestAsync($"/v2/checkout/orders/{orderId}/capture", async (req, ct) => await req
-                .WithHeader("Prefer", "return=representation")
-                .PostJsonAsync(null, cancellationToken: ct)
-                .ReceiveJson<PayPalOrder>().ConfigureAwait(false),
-                cancellationToken)
-                .ConfigureAwait(false);
+            try
+            {
+                PayPalOrder paypalOrder = await RequestAsync(
+                    $"/v2/checkout/orders/{orderId}/capture",
+                    async (req, ct) => await req
+                        .WithHeader("Prefer", "return=representation")
+                        .PostJsonAsync(null, cancellationToken: ct)
+                        .ReceiveJson<PayPalOrder>().ConfigureAwait(false),
+                    cancellationToken)
+                    .ConfigureAwait(false);
+
+                return paypalOrder;
+            }
+            catch (FlurlHttpException ex)
+            {
+                if (ex.Call.Response.StatusCode == 422)
+                {
+                    throw new PaymentDeclinedException();
+                }
+
+                throw;
+            }
         }
 
         public async Task<PayPalCapturePayment> CapturePaymentAsync(string paymentId, CancellationToken cancellationToken = default)

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "13.1.0",
+  "version": "13.1.1",
   "assemblyVersion": {
     "precision": "build"
   },


### PR DESCRIPTION
According to #4 , when a payment is rejected by PayPal, we do not create any new order. With this change, whenever a card is rejected for whatever reason, we create a new order in status "Error" so that the seller knows about the failed payment attempt and can do something about it.

![image](https://github.com/umbraco/Umbraco.Commerce.PaymentProviders.PayPal/assets/145000730/436747b5-2128-46ce-bf44-95c9266bf279)
